### PR TITLE
AWS deployment via Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,10 @@ before_install:
 
 before_script:
   - npm install -g ask-cli
+
+before_deploy:
+  - cd ../..
+
+deploy:
+  provider: script
+  script: ask deploy


### PR DESCRIPTION
Update Travis-CI config to deploy the skill to AWS using the ASK CLI during the deployment phase of a successful Travis-CI build on the master branch.

closes #2 
closes #3 